### PR TITLE
fix: Add optional delay right after setting up the strategy and before snapshotting

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -970,7 +970,8 @@
       drawHierarchyInKeyWindow: Bool,
       traits: UITraitCollection,
       view: UIView,
-      viewController: UIViewController
+      viewController: UIViewController,
+      wait: TimeInterval = 0
     )
       -> Async<UIImage>
     {
@@ -988,7 +989,7 @@
       return
         (view.snapshot
         ?? Async { callback in
-          addImagesForRenderedViews(view).sequence().run { views in
+            addImagesForRenderedViews(view).sequence().wait(for: wait).run { views in
             callback(
               renderer(bounds: view.bounds, for: traits).image { ctx in
                 if drawHierarchyInKeyWindow {

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -971,7 +971,7 @@
       traits: UITraitCollection,
       view: UIView,
       viewController: UIViewController,
-      wait: TimeInterval = 0
+      delay: TimeInterval = 0
     )
       -> Async<UIImage>
     {
@@ -989,7 +989,7 @@
       return
         (view.snapshot
         ?? Async { callback in
-            addImagesForRenderedViews(view).sequence().wait(for: wait).run { views in
+            addImagesForRenderedViews(view).sequence().wait(for: delay).run { views in
             callback(
               renderer(bounds: view.bounds, for: traits).image { ctx in
                 if drawHierarchyInKeyWindow {

--- a/Sources/SnapshotTesting/Extensions/Wait.swift
+++ b/Sources/SnapshotTesting/Extensions/Wait.swift
@@ -8,7 +8,7 @@ extension Snapshotting {
   /// stack).
   ///
   /// - Parameters:
-  ///   - duration: The amount of time to wait before taking the snapshot.
+  ///   - duration: The amount of time to wait before setting up and running the strategy.
   ///   - strategy: The snapshot to invoke after the specified amount of time has passed.
   public static func wait(
     for duration: TimeInterval,
@@ -32,7 +32,7 @@ extension Snapshotting {
 
 extension Async {
 
-    /// Wraps the asynchronous operation within another which executes the original callback after the wait's `duration`
+    /// Wraps the asynchronous operation within another which executes the original callback after the wait's `duration`.
     func wait(for duration: TimeInterval) -> Async<Value> {
         return Async<Value> { callback in
             run { value in

--- a/Sources/SnapshotTesting/Extensions/Wait.swift
+++ b/Sources/SnapshotTesting/Extensions/Wait.swift
@@ -29,3 +29,17 @@ extension Snapshotting {
       })
   }
 }
+
+extension Async {
+
+    /// Wraps the asynchronous operation within another which executes the original callback after the wait's `duration`
+    func wait(for duration: TimeInterval) -> Async<Value> {
+        return Async<Value> { callback in
+            run { value in
+                DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
+                    callback(value)
+                }
+            }
+        }
+    }
+}

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -18,6 +18,7 @@
     ///     human eye.
     ///   - size: A view size override.
     ///   - traits: A trait collection override.
+    ///   - wait: The amount of time to wait before taking the snapshot.
     public static func image(
       on config: ViewImageConfig,
       precision: Float = 1,

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -18,14 +18,14 @@
     ///     human eye.
     ///   - size: A view size override.
     ///   - traits: A trait collection override.
-    ///   - wait: The amount of time to wait before taking the snapshot.
+    ///   - delay: The amount of time to wait after rendering the view and before taking the snapshot.
     public static func image(
       on config: ViewImageConfig,
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
       traits: UITraitCollection = .init(),
-      wait: TimeInterval = 0
+      delay: TimeInterval = 0
     )
       -> Snapshotting
     {
@@ -40,7 +40,7 @@
           traits: traits,
           view: viewController.view,
           viewController: viewController,
-          wait: wait
+          delay: delay
         )
       }
     }

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -23,7 +23,8 @@
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
-      traits: UITraitCollection = .init()
+      traits: UITraitCollection = .init(),
+      wait: TimeInterval = 0
     )
       -> Snapshotting
     {
@@ -37,7 +38,8 @@
           drawHierarchyInKeyWindow: false,
           traits: traits,
           view: viewController.view,
-          viewController: viewController
+          viewController: viewController,
+          wait: wait
         )
       }
     }


### PR DESCRIPTION
This enables the (minimal) wait for images (and other content) that might be loaded asynchronously in the target view(s).